### PR TITLE
Should be ft=jsx

### DIFF
--- a/ftdetect/jsx.vim
+++ b/ftdetect/jsx.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufRead *.jsx set filetype=jsx


### PR DESCRIPTION
When opening `*.jsx` file, filetype becomes `javascript` instead of `jsx`.
